### PR TITLE
Use native JS types instead of ObjC types in the JSON Response body. #2.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-/* globals NSHTTPURLResponse NSString NSASCIIStringEncoding MOPointer NSJSONSerialization coscript NSURL NSMutableURLRequest NSMutableData NSURLConnection */
+/* globals NSHTTPURLResponse NSString NSASCIIStringEncoding NSUTF8StringEncoding MOPointer NSJSONSerialization coscript NSURL NSMutableURLRequest NSMutableData NSURLConnection */
 var MochaJSDelegate = require('mocha-js-delegate')
 
 function response (httpResponse, data) {
@@ -34,12 +34,13 @@ function response (httpResponse, data) {
     },
     json () {
       return new Promise((resolve, reject) => {
-        const err = MOPointer.alloc().initWithValue(null)
-        const obj = NSJSONSerialization.JSONObjectWithData_options_error(data, 0, err)
-        if (obj) {
+        const str = NSString.alloc().initWithData_encoding(data, NSUTF8StringEncoding)
+        if (str) {
+          // parse errors are turned into exceptions, which cause promise to be rejected
+          const obj = JSON.parse(str)
           resolve(obj)
         } else {
-          reject(err.value())
+          reject(new Error("Could not parse JSON because it is not valid UTF-8 data."))
         }
       })
     },


### PR DESCRIPTION
I asked someone who makes sketch plugins at fb and AFICT, the consensus is to use pure JS types all the way through a plugin as possible.