### PR TITLE
Use cocoascript-class to avoid downsides of MochaJSDelegate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ function fetch (urlString, options) {
     if (!DelegateClass) {
       DelegateClass = ObjCClass({
         classname: 'FetchPolyfillDelegate',
-        data: NSMutableData.alloc().init(),
+        data: null,
         httpResponse: null,
         callbacks: null,
 
@@ -95,11 +95,11 @@ function fetch (urlString, options) {
         },
         'connection:didReceiveResponse:' (connection, httpResponse) {
           this.httpResponse = httpResponse
+          this.data = NSMutableData.alloc().init()
         },
         'connection:didFailWithError:' (connection, error) {
           coscript.setShouldKeepAround(false)
-          const reject = this.callbacks.reject;
-          return reject(error)
+          return this.callbacks.reject(error)
         },
         'connection:didReceiveData:' (connection, data) {
           this.data.appendData(data)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,8 @@
 /* globals NSHTTPURLResponse NSString NSASCIIStringEncoding NSUTF8StringEncoding MOPointer NSJSONSerialization coscript NSURL NSMutableURLRequest NSMutableData NSURLConnection */
-var MochaJSDelegate = require('mocha-js-delegate')
+
+var _ObjCClass = require('cocoascript-class');
+
+const ObjCClass = _ObjCClass.default;
 
 function response (httpResponse, data) {
   const keys = []
@@ -60,6 +63,29 @@ function response (httpResponse, data) {
   }
 }
 
+const DelegateClass = ObjCClass({
+  _data: NSMutableData.alloc().init(),
+  _httpResponse: null,
+  _callbacks: null,
+
+  'connectionDidFinishLoading:' (connection) {
+    coscript.setShouldKeepAround(false)
+    return this._callbacks.resolve(response(this._httpResponse, this._data))
+  },
+  'connection:didReceiveResponse:' (connection, httpResponse) {
+    this._httpResponse = httpResponse
+  },
+  'connection:didFailWithError:' (connection, error) {
+    coscript.setShouldKeepAround(false)
+    const reject = this._callbacks.reject;
+    return reject(error)
+  },
+  'connection:didReceiveData:' (connection, _data) {
+    this._data.appendData(_data)
+  }
+});
+
+
 function fetch (urlString, options) {
   options = options || {}
   coscript.setShouldKeepAround(true)
@@ -79,24 +105,16 @@ function fetch (urlString, options) {
     const data = NSMutableData.alloc().init()
     let httpResponse
 
-    const connectionDelegate = new MochaJSDelegate({
-      'connectionDidFinishLoading:' (connection) {
-        coscript.setShouldKeepAround(false)
-        return resolve(response(httpResponse, data))
-      },
-      'connection:didReceiveResponse:' (connection, _httpResponse) {
-        httpResponse = _httpResponse
-      },
-      'connection:didFailWithError:' (connection, error) {
-        coscript.setShouldKeepAround(false)
-        return reject(error)
-      },
-      'connection:didReceiveData:' (connection, _data) {
-        data.appendData(_data)
-      }
-    })
+    const connectionDelegate = DelegateClass.new();
+    log("setting callbacks");
+    connectionDelegate._callbacks = NSDictionary.dictionaryWithDictionary({
+      resolve,
+      reject
+    });
+    // connectionDelegate._resolve = (d) => {log("in resolve"); resolve(d); }
+    log("done setting callbacks");
 
-    NSURLConnection.alloc().initWithRequest_delegate_startImmediately(request, connectionDelegate.getClassInstance(), true)
+    NSURLConnection.alloc().initWithRequest_delegate_startImmediately(request, connectionDelegate, true)
   })
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,28 +63,8 @@ function response (httpResponse, data) {
   }
 }
 
-const DelegateClass = ObjCClass({
-  _data: NSMutableData.alloc().init(),
-  _httpResponse: null,
-  _callbacks: null,
-
-  'connectionDidFinishLoading:' (connection) {
-    coscript.setShouldKeepAround(false)
-    return this._callbacks.resolve(response(this._httpResponse, this._data))
-  },
-  'connection:didReceiveResponse:' (connection, httpResponse) {
-    this._httpResponse = httpResponse
-  },
-  'connection:didFailWithError:' (connection, error) {
-    coscript.setShouldKeepAround(false)
-    const reject = this._callbacks.reject;
-    return reject(error)
-  },
-  'connection:didReceiveData:' (connection, _data) {
-    this._data.appendData(_data)
-  }
-});
-
+// We create one ObjC class for ourselves here
+let DelegateClass
 
 function fetch (urlString, options) {
   options = options || {}
@@ -102,19 +82,38 @@ function fetch (urlString, options) {
       request.setHTTPBody(data)
     }
 
-    const data = NSMutableData.alloc().init()
-    let httpResponse
+    if (!DelegateClass) {
+      DelegateClass = ObjCClass({
+        classname: 'FetchPolyfillDelegate',
+        data: NSMutableData.alloc().init(),
+        httpResponse: null,
+        callbacks: null,
+
+        'connectionDidFinishLoading:' (connection) {
+          coscript.setShouldKeepAround(false)
+          return this.callbacks.resolve(response(this.httpResponse, this.data))
+        },
+        'connection:didReceiveResponse:' (connection, httpResponse) {
+          this.httpResponse = httpResponse
+        },
+        'connection:didFailWithError:' (connection, error) {
+          coscript.setShouldKeepAround(false)
+          const reject = this.callbacks.reject;
+          return reject(error)
+        },
+        'connection:didReceiveData:' (connection, data) {
+          this.data.appendData(data)
+        }
+      });
+    }
 
     const connectionDelegate = DelegateClass.new();
-    log("setting callbacks");
-    connectionDelegate._callbacks = NSDictionary.dictionaryWithDictionary({
+    connectionDelegate.callbacks = NSDictionary.dictionaryWithDictionary({
       resolve,
       reject
     });
-    // connectionDelegate._resolve = (d) => {log("in resolve"); resolve(d); }
-    log("done setting callbacks");
 
-    NSURLConnection.alloc().initWithRequest_delegate_startImmediately(request, connectionDelegate, true)
+    NSURLConnection.alloc().initWithRequest_delegate(request, connectionDelegate)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A fetch polyfill for sketch",
   "main": "lib/index.js",
   "dependencies": {
-    "mocha-js-delegate": "^0.1.1"
+    "cocoascript-class": "^0.1.1"
   },
   "devDependencies": {
     "standard": "^8.6.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A fetch polyfill for sketch",
   "main": "lib/index.js",
   "dependencies": {
-    "cocoascript-class": "^0.1.1"
+    "cocoascript-class": "^0.1.2"
   },
   "devDependencies": {
     "standard": "^8.6.0"


### PR DESCRIPTION
- only creates one class, no matter how many times you create
- uses real objc ivars, doesn't need to capture anything