### PR TITLE
ensure multiple requests clean their own fibers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,13 +101,14 @@ function fetch (urlString, options) {
         classname: 'FetchPolyfillDelegate',
         data: null,
         httpResponse: null,
+        fiber: null,
         callbacks: null,
 
         'connectionDidFinishLoading:': function (connection) {
           finished = true
           this.callbacks.resolve(response(this.httpResponse, this.data))
-          if (fiber) {
-            fiber.cleanup()
+          if (this.fiber) {
+            this.fiber.cleanup()
           } else {
             coscript.shouldKeepAround = false
           }
@@ -119,8 +120,8 @@ function fetch (urlString, options) {
         'connection:didFailWithError:': function (connection, error) {
           finished = true
           this.callbacks.reject(error)
-          if (fiber) {
-            fiber.cleanup()
+          if (this.fiber) {
+            this.fiber.cleanup()
           } else {
             coscript.shouldKeepAround = false
           }
@@ -136,6 +137,7 @@ function fetch (urlString, options) {
       resolve: resolve,
       reject: reject
     })
+    connectionDelegate.fiber = fiber;
 
     var connection = NSURLConnection.alloc().initWithRequest_delegate(
       request,


### PR DESCRIPTION
If there are multiple requests, `DelegateClass` always had the same `fiber` in its closure, so it was only shutting one of the fibers, meaning the context never got cleared up