### PR TITLE
Allow NSData objects to be sent in request body

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,8 @@ function fetch (urlString, options) {
       if (typeof options.body === 'string') {
         var str = NSString.alloc().initWithString(options.body)
         data = str.dataUsingEncoding(NSUTF8StringEncoding)
+      } else if (options.body.isKindOfClass && (options.body.isKindOfClass(NSData) == 1) ) {
+        data = options.body
       } else {
         var error
         data = NSJSONSerialization.dataWithJSONObject_options_error(options.body, NSJSONWritingPrettyPrinted, error)


### PR DESCRIPTION
This will allow passing NSData objects in request body: `NSData.readBinaryFile(fullpathFilename)`

Currently everything except a string is serialized with JSON, which prevents us from sending binary data through fetch.

I'm not sure this is the best check to run here, happy to apply any suggestions.